### PR TITLE
Got rid of green arrow when editing list name & fixed modal name

### DIFF
--- a/app/assets/stylesheets/components/_forms.scss
+++ b/app/assets/stylesheets/components/_forms.scss
@@ -2,7 +2,6 @@
   text-align:center;
 }
 
-
 .inner-form-container {
   padding: 15px;
   // border: 1px solid #0294A5;
@@ -68,7 +67,7 @@ justify-content: start;
   padding: 0 !important;
 }
 
-#list_name{
+#list_name_edit{
   border-bottom: 0px !important;
   font-size: 40px;
   color: black;

--- a/app/views/lists/edit.html.erb
+++ b/app/views/lists/edit.html.erb
@@ -2,7 +2,7 @@
   <div class="row justify-content-around">
     <div class="col-lg-6" id = "left-part">
       <%= simple_form_for(@list, method: :patch) do |f| %>
-      <%= f.input :name, label: false %>
+      <%= f.input :name, label: false, input_html: { id: :list_name_edit }, required: false%>
       <%= f.input :description, placeholder: 'Describe this list' , label_html: { class: 'form' }, label: false %>
       <%= f.input :photo , label: 'Please select a picture for your list:' %>
       <%= f.input :photo_cache, label_html: { class: 'form' }, as: :hidden %>

--- a/app/views/shared/_modal.html.erb
+++ b/app/views/shared/_modal.html.erb
@@ -6,7 +6,7 @@
       </div>
       <div class="modal-body">
         <%= simple_form_for(List.new) do |form| %>
-        <%= form.input :name, as: :text %>
+        <%= form.input :name, as: :text, label: 'List name:' %>
       </div>
       <div class="modal-footer">
         <button type="button" class="btn-info "><%= form.button :submit %></button>

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -58,7 +58,7 @@ SimpleForm.setup do |config|
     b.optional :min_max
     b.optional :readonly
     b.use :label, class: 'form-control-label'
-    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :input, class: 'form-control', error_class: 'is-invalid' #,valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end
@@ -107,7 +107,7 @@ SimpleForm.setup do |config|
     b.optional :minlength
     b.optional :readonly
     b.use :label
-    b.use :input, class: 'form-control-file', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :input, class: 'form-control-file', error_class: 'is-invalid'#, valid_class: 'is-valid'
     b.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
     b.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end
@@ -150,7 +150,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'col-sm-3 col-form-label'
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :input, class: 'form-control', error_class: 'is-invalid'#, valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
       ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
     end
@@ -206,7 +206,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'col-sm-3 form-control-label'
     b.wrapper :grid_wrapper, tag: 'div', class: 'col-sm-9' do |ba|
-      ba.use :input, error_class: 'is-invalid', valid_class: 'is-valid'
+      ba.use :input, error_class: 'is-invalid'#, valid_class: 'is-valid'
       ba.use :full_error, wrap_with: { tag: 'div', class: 'invalid-feedback d-block' }
       ba.use :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
     end
@@ -254,7 +254,7 @@ SimpleForm.setup do |config|
     b.optional :readonly
     b.use :label, class: 'sr-only'
 
-    b.use :input, class: 'form-control', error_class: 'is-invalid', valid_class: 'is-valid'
+    b.use :input, class: 'form-control', error_class: 'is-invalid'#, valid_class: 'is-valid'
     b.use :error, wrap_with: { tag: 'div', class: 'invalid-feedback' }
     b.optional :hint, wrap_with: { tag: 'small', class: 'form-text text-muted' }
   end


### PR DESCRIPTION
remove the valid_class: 'is-valid from the input in the wrapper (simple_form_bootstrap.rb)
created own id for edit list name